### PR TITLE
[ fix ] remove duplicate implicit argument

### DIFF
--- a/CS410-19/Exercise/One.agda
+++ b/CS410-19/Exercise/One.agda
@@ -269,7 +269,7 @@ module _ {X : Set} where
 
 -- Give composition for thinnings. Minimize the number of cases.
 
-  _-<-_ : forall {X}{xs ys zs : List X} -> xs <: ys -> ys <: zs -> xs <: zs
+  _-<-_ : forall {xs ys zs : List X} -> xs <: ys -> ys <: zs -> xs <: zs
   th -<- ph = {!!}
 
   infixl 40 _-<-_


### PR DESCRIPTION
Thanks to Ash. There is already an `X` coming from the surrounding module.