### PR TITLE
[ fix ] rename Splitting constructors for fwd lists

### DIFF
--- a/CS410-19/Exercise/One.agda
+++ b/CS410-19/Exercise/One.agda
@@ -374,14 +374,14 @@ module _ {X : Set} where
   data Splitting : {xs ys zs : List X}
                    (th : xs <: zs)(ph : ys <: zs) 
                 -> Set where
-    _-^,_ : forall w {xs ys zs}{th : xs <: zs}{ph : ys <: zs} ->
+    _^,-_ : forall w {xs ys zs}{th : xs <: zs}{ph : ys <: zs} ->
                Splitting th ph ->
                Splitting (w ^- th) (w ,- ph)
-    _-,^_ : forall w {xs ys zs}{th : xs <: zs}{ph : ys <: zs} ->
+    _,^-_ : forall w {xs ys zs}{th : xs <: zs}{ph : ys <: zs} ->
                Splitting th ph ->
                Splitting (w ,- th) (w ^- ph)
     [] : Splitting [] []
-  infixr 60 _-^,_ _-,^_
+  infixr 60 _^,-_ _,^-_
 
 -- Show that if we know how xs <: zs, we can find a splitting of zs by
 -- computing...


### PR DESCRIPTION
Maybe this one is a little awkward to fix, but knowing your conventions, I think it's the right thing. I only noticed it in doing exercise 3; maybe that one splitting we had to create in exercise 1 could be done by auto.

All that is affected in students' answers is the end of exercise 1, and any of exercise 3 for the few who have started that.